### PR TITLE
V2 refine further

### DIFF
--- a/lgatr/primitives/__init__.py
+++ b/lgatr/primitives/__init__.py
@@ -4,6 +4,6 @@ from .attention import sdp_attention
 from .bilinear import geometric_product
 from .config import PrimitivesConfig
 from .dropout import grade_dropout
-from .invariants import abs_squared_norm, inner_product
+from .invariants import abs_squared_norm, inner_product, inner_product_factors
 from .linear import equi_linear, grade_involute, grade_project, reverse
 from .normalization import equi_layer_norm

--- a/lgatr/primitives/invariants.py
+++ b/lgatr/primitives/invariants.py
@@ -15,15 +15,17 @@ _INNER_PRODUCT_FACTORS = torch.tensor(
     device=DEFAULT_DEVICE,
 )
 
-
 @lru_cache
-def _load_inner_product_factors(
+def inner_product_factors(
     device: torch.device = DEFAULT_DEVICE,
     dtype: torch.dtype = DEFAULT_DTYPE,
 ) -> torch.Tensor:
     # Diagonal of the GA metric used by the inner product, shape (16,) (+/-1 entries).
     return _INNER_PRODUCT_FACTORS.to(device=device, dtype=dtype)
 
+
+# Backward-compatible private alias for code that relied on the old name (optional)
+_load_inner_product_factors = inner_product_factors
 
 @lru_cache
 def _load_metric_grades(


### PR DESCRIPTION
Public inner_product_factors

lgatr.primitives.inner_product_factors replaces the private _load_inner_product_factors (kept as an alias). LLoCa folds this metric diagonal into flattened query/key tensors exactly as sdp_attention does, and needs a public way to get it. Using inner_product instead would change the summation order, so this keeps results bitwise identical.

not implemented but worth noting, affine_norm is 2d and wouldn't get weight decay exemption automatically under most setups (including lloca-experiments)

new attention backend changes break amp i think

fully deprecating inner factors and all its dependencies plus more details on that are in https://github.com/heidelberg-hepml/lloca/pull/15

scale comment only true for torch 2.10?

`norm_elementwise_affine=True` in all normalization operations" is true in all blocks but not in say `GeometricBilinear `where the `EquiLayerNorm()` doesn't have it true